### PR TITLE
dune: upgrade to dune 2.0 and later

### DIFF
--- a/linux/dune
+++ b/linux/dune
@@ -1,3 +1,4 @@
 (library
   (name linux)
-  (c_names linux_stubs))
+  (foreign_stubs (language c) (names linux_stubs))
+)


### PR DESCRIPTION
Failure log on `build @all` without this change:

```
$ dune build @all
Info: Creating file dune-project with this contents:
| (lang dune 2.9)
File "linux/dune", line 3, characters 2-23:
3 |   (c_names linux_stubs))
      ^^^^^^^^^^^^^^^^^^^^^
Error: 'c_names' was deleted in version 2.0 of the dune language. Use the
(foreign_stubs ...) field instead.
```